### PR TITLE
Convert BosonUSB to bosond

### DIFF
--- a/BosonUSB.cpp
+++ b/BosonUSB.cpp
@@ -11,213 +11,186 @@
 
 using namespace cv;
 
-// Global variables to keep this simple
-int width;
-int height;
+void inspect(Mat input_16, int height, int width) {
+    int i, j;  // aux variables
 
+    // auxiliary variables for AGC calcultion
+    unsigned int max1=0;         // 16 bits
+    unsigned int min1=0xFFFF;    // 16 bits
+    unsigned int value1, value2, value3;
 
-/* ---------------------------- 16 bits Mode auxiliary functions ---------------------------------------*/
+    // RUN a super basic AGC
+    for (i=0; i<height; i++) {
+        for (j=0; j<width; j++) {
+            if (i==0 && j==0) {
+                unsigned int x = input_16.at<unsigned short>(i, j);
+                printf("x=%d\n", x);
+                unsigned int y = ((x & 0xff00) >> 8) + ((x & 0xff) << 8);
+                printf("y=%d\n", y);
+            }
 
-// AGC Sample ONE: Linear from min to max.
-// Input is a MATRIX (height x width) of 16bits. (OpenCV mat)
-// Output is a MATRIX (height x width) of 8 bits (OpenCV mat)
-void AGC_Basic_Linear(Mat input_16, Mat output_8, int height, int width) {
-	int i, j;  // aux variables
+            value1 =  input_16.at<uchar>(i,j*2+1) & 0XFF ;  // High Byte
+            value2 =  input_16.at<uchar>(i,j*2) & 0xFF  ;    // Low Byte
+            value3 = ( value1 << 8) + value2;
+            if ( value3 <= min1 ) {
+                min1 = value3;
+            }
+            if ( value3 >= max1 ) {
+                max1 = value3;
+            }
+        }
+    }
 
-	// auxiliary variables for AGC calcultion
-	unsigned int max1=0;         // 16 bits
-	unsigned int min1=0xFFFF;    // 16 bits
-	unsigned int value1, value2, value3, value4;
-
-	// RUN a super basic AGC
-	for (i=0; i<height; i++) {
-		for (j=0; j<width; j++) {
-			value1 =  input_16.at<uchar>(i,j*2+1) & 0XFF ;  // High Byte
-			value2 =  input_16.at<uchar>(i,j*2) & 0xFF  ;    // Low Byte
-			value3 = ( value1 << 8) + value2;
-			if ( value3 <= min1 ) {
-				min1 = value3;
-			}
-			if ( value3 >= max1 ) {
-				max1 = value3;
-			}
-			//printf("%X.%X.%X  ", value1, value2, value3);
-		}
-	}
-	//printf("max1=%04X, min1=%04X\n", max1, min1);
-
-	for (int i=0; i<height; i++) {
-		for (int j=0; j<width; j++) {
-			value1 =  input_16.at<uchar>(i,j*2+1) & 0XFF ;  // High Byte
-			value2 =  input_16.at<uchar>(i,j*2) & 0xFF  ;    // Low Byte
-			value3 = ( value1 << 8) + value2;
-			value4 = ( ( 255 * ( value3 - min1) ) ) / (max1-min1)   ;
-			// printf("%04X \n", value4);
-
-			output_8.at<uchar>(i,j)= (uchar)(value4&0xFF);
-		}
-	}
-
+    printf("min=%d max=%d\n", min1, max1);
 }
 
 
-/* ---------------------------- Main Function ---------------------------------------*/
-// ENTRY POINT
 int main(int argc, char** argv)
 {
-	int fd;
-	struct v4l2_capability cap;
-	char video[20];   // To store Video Port Device
-	char label[50];   // To display the information
-	char thermal_sensor_name[20];  // To store the sensor name
+    int fd;
+    struct v4l2_capability cap;
+    char video[20];   // To store Video Port Device
+    char label[50];   // To display the information
+    char thermal_sensor_name[20];  // To store the sensor name
+    int width;
+    int height;
 
-	// To record images
-	std::vector<int> compression_params;
-	compression_params.push_back(IMWRITE_PXM_BINARY);
+    // To record images
+    std::vector<int> compression_params;
+    compression_params.push_back(IMWRITE_PXM_BINARY);
 
-	// Video device by default
-	sprintf(video, "/dev/video1");
-	sprintf(thermal_sensor_name, "Boson_640");
-        width=640;
-        height=512;
+    // Video device by default
+    sprintf(video, "/dev/video1");
+    sprintf(thermal_sensor_name, "Boson_640");
+    width=640;
+    height=512;
 
-	if((fd = open(video, O_RDWR)) < 0){
-		perror("Error : OPEN. Invalid Video Device\n");
-		exit(1);
-	}
+    if((fd = open(video, O_RDWR)) < 0){
+        perror("Error : OPEN. Invalid Video Device\n");
+        exit(1);
+    }
 
-	// Check VideoCapture mode is available
-	if(ioctl(fd, VIDIOC_QUERYCAP, &cap) < 0){
-	    perror("ERROR : VIDIOC_QUERYCAP. Video Capture is not available\n");
-	    exit(1);
-	}
+    // Check VideoCapture mode is available
+    if(ioctl(fd, VIDIOC_QUERYCAP, &cap) < 0){
+        perror("ERROR : VIDIOC_QUERYCAP. Video Capture is not available\n");
+        exit(1);
+    }
 
-	if(!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE)){
-		fprintf(stderr, "The device does not handle single-planar video capture.\n");
-		exit(1);
-	}
+    if(!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE)){
+        fprintf(stderr, "The device does not handle single-planar video capture.\n");
+        exit(1);
+    }
 
-	struct v4l2_format format;
+    struct v4l2_format format;
 
-	// Common varibles
-	format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-        format.fmt.pix.pixelformat = V4L2_PIX_FMT_Y16;
-	format.fmt.pix.width = width;
-	format.fmt.pix.height = height;
+    // Common varibles
+    format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    format.fmt.pix.pixelformat = V4L2_PIX_FMT_Y16;
+    format.fmt.pix.width = width;
+    format.fmt.pix.height = height;
 
-	// request desired FORMAT
-	if(ioctl(fd, VIDIOC_S_FMT, &format) < 0){
-		perror("VIDIOC_S_FMT");
-		exit(1);
-	}
+    // request desired FORMAT
+    if(ioctl(fd, VIDIOC_S_FMT, &format) < 0){
+        perror("VIDIOC_S_FMT");
+        exit(1);
+    }
 
-	// we need to inform the device about buffers to use.
-	// and we need to allocate them.
-	// we’ll use a single buffer, and map our memory using mmap.
-	// All this information is sent using the VIDIOC_REQBUFS call and a
-	// v4l2_requestbuffers structure:
-	struct v4l2_requestbuffers bufrequest;
-	bufrequest.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-	bufrequest.memory = V4L2_MEMORY_MMAP;
-	bufrequest.count = 1;   // we are asking for one buffer
+    // we need to inform the device about buffers to use.
+    // and we need to allocate them.
+    // we’ll use a single buffer, and map our memory using mmap.
+    // All this information is sent using the VIDIOC_REQBUFS call and a
+    // v4l2_requestbuffers structure:
+    struct v4l2_requestbuffers bufrequest;
+    bufrequest.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    bufrequest.memory = V4L2_MEMORY_MMAP;
+    bufrequest.count = 1;   // we are asking for one buffer
 
-	if(ioctl(fd, VIDIOC_REQBUFS, &bufrequest) < 0){
-		perror("VIDIOC_REQBUFS");
-		exit(1);
-	}
+    if(ioctl(fd, VIDIOC_REQBUFS, &bufrequest) < 0){
+        perror("VIDIOC_REQBUFS");
+        exit(1);
+    }
 
-	// Now that the device knows how to provide its data,
-	// we need to ask it about the amount of memory it needs,
-	// and allocate it. This information is retrieved using the VIDIOC_QUERYBUF call,
-	// and its v4l2_buffer structure.
+    // Now that the device knows how to provide its data,
+    // we need to ask it about the amount of memory it needs,
+    // and allocate it. This information is retrieved using the VIDIOC_QUERYBUF call,
+    // and its v4l2_buffer structure.
+    struct v4l2_buffer bufferinfo;
+    memset(&bufferinfo, 0, sizeof(bufferinfo));
 
-	struct v4l2_buffer bufferinfo;
-	memset(&bufferinfo, 0, sizeof(bufferinfo));
+    bufferinfo.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    bufferinfo.memory = V4L2_MEMORY_MMAP;
+    bufferinfo.index = 0;
 
-	bufferinfo.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-	bufferinfo.memory = V4L2_MEMORY_MMAP;
-	bufferinfo.index = 0;
+    if(ioctl(fd, VIDIOC_QUERYBUF, &bufferinfo) < 0){
+        perror("VIDIOC_QUERYBUF");
+        exit(1);
+    }
 
-	if(ioctl(fd, VIDIOC_QUERYBUF, &bufferinfo) < 0){
-		perror("VIDIOC_QUERYBUF");
-		exit(1);
-	}
+    // map fd+offset into a process location (kernel will decide due to our NULL). lenght and
+    // properties are also passed
+    printf(">>> Image width   = %i\n", width);
+    printf(">>> Image height  = %i\n", height);
+    printf(">>> Buffer length = %i\n", bufferinfo.length);
 
+    void * buffer_start = mmap(NULL, bufferinfo.length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, bufferinfo.m.offset);
+    if (buffer_start == MAP_FAILED) {
+        perror("mmap");
+        exit(1);
+    }
 
-	// map fd+offset into a process location (kernel will decide due to our NULL). lenght and
-	// properties are also passed
-	printf(">>> Image width   = %i\n", width);
-	printf(">>> Image height  = %i\n", height);
-	printf(">>> Buffer length = %i\n", bufferinfo.length);
+    // Fill this buffer with ceros. Initialization. Optional but nice to do
+    memset(buffer_start, 0, bufferinfo.length);
 
-	void * buffer_start = mmap(NULL, bufferinfo.length, PROT_READ | PROT_WRITE,MAP_SHARED, fd, bufferinfo.m.offset);
-
-	if(buffer_start == MAP_FAILED){
-		perror("mmap");
-		exit(1);
-	}
-
-	// Fill this buffer with ceros. Initialization. Optional but nice to do
-	memset(buffer_start, 0, bufferinfo.length);
-
-	// Activate streaming
-	int type = bufferinfo.type;
-	if(ioctl(fd, VIDIOC_STREAMON, &type) < 0){
-		perror("VIDIOC_STREAMON");
-		exit(1);
-	}
-
-
-	// Declarations for RAW16 representation
-        // Will be used in case we are reading RAW16 format
-	// Boson320 , Boson 640
-	Mat thermal16(height, width, CV_16U, buffer_start);   // OpenCV input buffer  : Asking for all info: two bytes per pixel (RAW16)  RAW16 mode`
-	Mat thermal16_linear(height,width, CV_8U, 1);         // OpenCV output buffer : Data used to display the video
-
-	// Declarations for Zoom representation
-    	// Will be used or not depending on program arguments
-	Size size(640,512);
-	Mat thermal16_linear_zoom;   // (height,width, CV_8U, 1);    // Final representation
-
-	// Reaad frame, do AGC, paint frame
-	for (;;) {
-
-		// Put the buffer in the incoming queue.
-		if(ioctl(fd, VIDIOC_QBUF, &bufferinfo) < 0){
-			perror("VIDIOC_QBUF");
-			exit(1);
-		}
-
-		// The buffer's waiting in the outgoing queue.
-		if(ioctl(fd, VIDIOC_DQBUF, &bufferinfo) < 0) {
-			perror("VIDIOC_QBUF");
-			exit(1);
-		}
+    // Activate streaming
+    int type = bufferinfo.type;
+    if(ioctl(fd, VIDIOC_STREAMON, &type) < 0){
+        perror("VIDIOC_STREAMON");
+        exit(1);
+    }
 
 
-		// -----------------------------
-		// RAW16 DATA
-                AGC_Basic_Linear(thermal16, thermal16_linear, height, width);
+    // Declarations for RAW16 representation
+    // Will be used in case we are reading RAW16 format
+    // Boson320 , Boson 640
+    Mat thermal16(height, width, CV_16U, buffer_start);   // OpenCV input buffer  : Asking for all info: two bytes per pixel (RAW16)  RAW16 mode`
 
-                // Display thermal after 16-bits AGC... will display an image
-                resize(thermal16_linear, thermal16_linear_zoom, size);
-                sprintf(label, "%s : RAW16  Linear Zoom", thermal_sensor_name);
-                imshow(label, thermal16_linear_zoom);
+    // Declarations for Zoom representation
+    // Will be used or not depending on program arguments
+    Size size(640,512);
 
-		// Press 'q' to exit
-		if( waitKey(1) == 'q' ) { // 0x20 (SPACE) ; need a small delay !! we use this to also add an exit option
-			printf(">>> 'q' key pressed. Quitting !\n");
-			break;
-		}
-	}
-	// Finish Loop . Exiting.
+    // Reaad frame, do AGC, paint frame
+    for (;;) {
 
-	// Deactivate streaming
-	if( ioctl(fd, VIDIOC_STREAMOFF, &type) < 0 ){
-		perror("VIDIOC_STREAMOFF");
-		exit(1);
-	};
+        // Put the buffer in the incoming queue.
+        if(ioctl(fd, VIDIOC_QBUF, &bufferinfo) < 0){
+            perror("VIDIOC_QBUF");
+            exit(1);
+        }
 
-	close(fd);
-	return EXIT_SUCCESS;
+        // The buffer's waiting in the outgoing queue.
+        if(ioctl(fd, VIDIOC_DQBUF, &bufferinfo) < 0) {
+            perror("VIDIOC_QBUF");
+            exit(1);
+        }
+
+        // cv::Scalar v = cv::mean(thermal16);
+        // printf("%.0f\n", v.val[0]);
+
+        inspect(thermal16, height, width);
+
+        if (waitKey(1) == 'q') {
+            printf(">>> 'q' key pressed. Quitting !\n");
+            break;
+        }
+    }
+    // Finish Loop . Exiting.
+
+    // Deactivate streaming
+    if( ioctl(fd, VIDIOC_STREAMOFF, &type) < 0 ){
+        perror("VIDIOC_STREAMOFF");
+        exit(1);
+    };
+
+    close(fd);
+    return EXIT_SUCCESS;
 }

--- a/BosonUSB.cpp
+++ b/BosonUSB.cpp
@@ -1,72 +1,19 @@
-/*
-------------------------------------------------------------------------
--  FLIR Systems - Linux Boson  Capture & Recording                     -
-------------------------------------------------------------------------
--  This code is using part of the explanations from this page          -
--  https://jwhsmith.net/2014/12/capturing-a-webcam-stream-using-v4l2/  -
--                                                                      -
--  and completed to be used with FLIR Boson cameras in 16 and 8 bits.  -
--  Internal AGC for 16bits mode is very basic, with just the intention -
--  of showing how to make that image displayable                       - 
-------------------------------------------------------------------------
-
- BosonUSB [r/y/z/s/t/f] [0..9]
-	r    : raw16 bits video input (default)
-	y    : agc-8 bits video input
-	z    : zoom mode to 640x480 (only applies to raw16 input)
-        f<name> : record TIFFS in Folder <NAME>
-        t<number> : number of frames to record
-	s[b,B]  : camera size : b=boson320, B=boson640
-	[0..9]  : linux video port
-
-./BosonUSB   ->  opens Boson320 /dev/video0  in RAW16 mode
-./BosonUSB r ->  opens Boson320 /dev/video0  in RAW16 mode
-./BosonUSB y ->  opens Boson320 /dev/video0  in AGC-8bits mode
-./BosonUSB sB 1    ->  opens Boson640 /dev/video1  in RAW16 mode
-./BosonUSB sB y 2  ->  opens Boson640 /dev/video2  in AGC-8bits mode
-./BosonUSB fcap -> creates a folder named 'cap' and inside TIFF files (raw16, agc, yuv) will be located.
-
-*/
-
 #include <stdio.h>
 #include <fcntl.h>               // open, O_RDWR
 #include <opencv2/opencv.hpp>
 #include <unistd.h>              // close
 #include <sys/ioctl.h>           // ioctl
-#include <asm/types.h>           // videodev2.h
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <linux/videodev2.h>
 
 
-#define YUV   0
-#define RAW16 1
-
 using namespace cv;
-
-#define v_major 1
-#define v_minor 0
-
-// Define COLOR CODES
-#define RED   "\x1B[31m"
-#define GRN   "\x1B[32m"
-#define YEL   "\x1B[33m"
-#define BLU   "\x1B[34m"
-#define MAG   "\x1B[35m"
-#define CYN   "\x1B[36m"
-#define WHT   "\x1B[37m"
-#define RESET "\x1B[0m"
-
 
 // Global variables to keep this simple
 int width;
 int height;
-
-// Types of sensors supported
-enum sensor_types {
-  Boson320, Boson640
-};
 
 
 /* ---------------------------- 16 bits Mode auxiliary functions ---------------------------------------*/
@@ -114,174 +61,53 @@ void AGC_Basic_Linear(Mat input_16, Mat output_8, int height, int width) {
 }
 
 
-/* ---------------------------- Other Aux functions ---------------------------------------*/
-
-// HELP INFORMATION
-void print_help() {
-	printf(CYN "Boson Capture and Record Video tool v%i.%i" WHT "\n", v_major, v_minor);
-	printf(CYN "FLIR Systems" WHT "\n\n");
-	printf(WHT "use : " YEL "'BosonUSB r' " WHT "to capture in raw-16 bits mode   (default)\n");
-	printf(WHT "Use : " YEL "'BosonUSB y' " WHT "to capture in agc-8  bits mode\n");
-  	printf(WHT "Use : " YEL "'BosonUSB z' " WHT "Zoom to 640x512 (only in RAW) mode  (default ZOOM OFF)\n");
-	printf(WHT "Use : " YEL "'BosonUSB f<name>' " WHT "record TIFFS in Folder <NAME>\n");
-	printf(WHT "Use : " YEL "'BosonUSB f<name> t<frame_count>' " WHT "record TIFFS in Folder <NAME> and stop recording after <FRAME_COUNT> frames\n");
-	printf(WHT "Use : " YEL "'BosonUSB [0..9]'   " WHT "to open /dev/Video[0..9]  (default 0)\n");
-	printf(WHT "Use : " YEL "'BosonUSB s[b,B]'   " WHT "b=boson320, B=boson640   (default 320)\n");
-	printf(WHT "Press " YEL "'q' in video window " WHT " to quit\n");
-	printf("\n");
-}
-
 /* ---------------------------- Main Function ---------------------------------------*/
 // ENTRY POINT
-int main(int argc, char** argv )
+int main(int argc, char** argv)
 {
-	int ret;
 	int fd;
-	int i;
 	struct v4l2_capability cap;
-	long frame=0;     // First frame number enumeration
 	char video[20];   // To store Video Port Device
 	char label[50];   // To display the information
 	char thermal_sensor_name[20];  // To store the sensor name
-	char filename[60];  // PATH/File_count
-	char folder_name[30];  // To store the folder name
-        char video_frames_str[30];
-	// Default Program options
-	int  video_mode=RAW16;
-	int  video_frames=0;
-	int  zoom_enable=0;
-	int  record_enable=0;
-	sensor_types my_thermal=Boson320;
 
 	// To record images
 	std::vector<int> compression_params;
 	compression_params.push_back(IMWRITE_PXM_BINARY);
 
-	// Display Help
-	print_help();
-
 	// Video device by default
-	sprintf(video, "/dev/video0");
-	sprintf(thermal_sensor_name, "Boson_320");
+	sprintf(video, "/dev/video1");
+	sprintf(thermal_sensor_name, "Boson_640");
+        width=640;
+        height=512;
 
-	// Read command line arguments
-	for (i=0; i<argc; i++) {
-		// Check if RAW16 video is desired
-		if ( argv[i][0]=='r') {
-			video_mode=RAW16;
-		}
-		// Check if AGC video is desired
-		if ( argv[i][0]=='y') {
-			video_mode=YUV;
-		}
-		// Check if ZOOM to 640x512 is enabled
-		if ( argv[i][0]=='z') {
-        		zoom_enable=1;
-      		}
-		// Check if recording is enabled
-		if ( argv[i][0]=='f') {  // File name has to be more than two chars
-            		record_enable=1;
-            		if ( strlen(argv[i])>2 ) {
-                		strcpy(folder_name, argv[i]+1);
-            		}
-      		}
-		// Look for type/size of sensor
-		if ( argv[i][0]=='s') {
-          		switch ( argv[i][1] ) {
-            			case 'B'/* value */:
-                			my_thermal=Boson640;
-               				sprintf(thermal_sensor_name, "Boson_640");
-		        	        break;
-            			default:
-				        my_thermal=Boson320;
-				        sprintf(thermal_sensor_name, "Boson_320");
-          		}
-      		}
-		// Look for feedback in ASCII
-		if (argv[i][0]>='0' && argv[i][0]<='9') {
-			sprintf(video, "/dev/video%c",argv[i][0]);
-		}
-		// Look for frame count
-        	if ( argv[i][0]=='t') {
-            		if ( strlen(argv[i])>=2 ) {
-				strcpy(video_frames_str, argv[i]+1);
-                                video_frames = atoi( video_frames_str );
-                                printf(WHT ">>> Number of frames to record =" YEL "%i" WHT "\n", video_frames);
-            		}	
-        	}
-  	}
-
-	// Folder name
-	if (record_enable==1) {
-		if ( strlen(folder_name)<=1 ) {  // File name has to be more than two chars
-		        strcpy(folder_name, thermal_sensor_name);
-	        }
-	        mkdir(folder_name, 0700);
-	        chdir(folder_name);
-                printf(WHT ">>> Folder " YEL "%s" WHT " selected to record files\n", folder_name);
-  	}
-
-	// Printf Sensor defined
-	printf(WHT ">>> " YEL "%s" WHT " selected\n", thermal_sensor_name);
-
-	// We open the Video Device
-	printf(WHT ">>> " YEL "%s" WHT " selected\n", video);
 	if((fd = open(video, O_RDWR)) < 0){
-		perror(RED "Error : OPEN. Invalid Video Device" WHT "\n");
+		perror("Error : OPEN. Invalid Video Device\n");
 		exit(1);
 	}
 
 	// Check VideoCapture mode is available
 	if(ioctl(fd, VIDIOC_QUERYCAP, &cap) < 0){
-	    perror(RED "ERROR : VIDIOC_QUERYCAP. Video Capture is not available" WHT "\n");
+	    perror("ERROR : VIDIOC_QUERYCAP. Video Capture is not available\n");
 	    exit(1);
 	}
 
 	if(!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE)){
-		fprintf(stderr, RED "The device does not handle single-planar video capture." WHT "\n");
+		fprintf(stderr, "The device does not handle single-planar video capture.\n");
 		exit(1);
 	}
 
 	struct v4l2_format format;
 
-	// Two different FORMAT modes, 8 bits vs RAW16
-	if (video_mode==RAW16) {
-		printf(WHT ">>> " YEL "16 bits " WHT "capture selected\n");
-
-		// I am requiring thermal 16 bits mode
-		format.fmt.pix.pixelformat = V4L2_PIX_FMT_Y16;
-
-		// Select the frame SIZE (will depend on the type of sensor)
-		switch (my_thermal) {
-			case Boson320:  // Boson320
-			          	width=320;
-				        height=256;
-				        break;
-		        case Boson640:  // Boson640
-				        width=640;
-				        height=512;
-				        break;
-			default:  // Boson320
-				        width=320;
-				        height=256;
-				        break;
-		 }
-
-	} else { // 8- bits is always 640x512 (even for a Boson 320)
-		 printf(WHT ">>> " YEL "8 bits " WHT "YUV selected\n");
-	         format.fmt.pix.pixelformat = V4L2_PIX_FMT_YVU420; // thermal, works   LUMA, full Cr, full Cb
-		 width = 640;
-		 height = 512;
-	}
-
 	// Common varibles
 	format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        format.fmt.pix.pixelformat = V4L2_PIX_FMT_Y16;
 	format.fmt.pix.width = width;
 	format.fmt.pix.height = height;
 
 	// request desired FORMAT
 	if(ioctl(fd, VIDIOC_S_FMT, &format) < 0){
-		perror(RED "VIDIOC_S_FMT" WHT);
+		perror("VIDIOC_S_FMT");
 		exit(1);
 	}
 
@@ -296,7 +122,7 @@ int main(int argc, char** argv )
 	bufrequest.count = 1;   // we are asking for one buffer
 
 	if(ioctl(fd, VIDIOC_REQBUFS, &bufrequest) < 0){
-		perror(RED "VIDIOC_REQBUFS" WHT);
+		perror("VIDIOC_REQBUFS");
 		exit(1);
 	}
 
@@ -313,21 +139,21 @@ int main(int argc, char** argv )
 	bufferinfo.index = 0;
 
 	if(ioctl(fd, VIDIOC_QUERYBUF, &bufferinfo) < 0){
-		perror(RED "VIDIOC_QUERYBUF" WHT);
+		perror("VIDIOC_QUERYBUF");
 		exit(1);
 	}
 
 
 	// map fd+offset into a process location (kernel will decide due to our NULL). lenght and
 	// properties are also passed
-	printf(WHT ">>> Image width  =" YEL "%i" WHT "\n", width);
-	printf(WHT ">>> Image height =" YEL "%i" WHT "\n", height);
-	printf(WHT ">>> Buffer lenght=" YEL "%i" WHT "\n", bufferinfo.length);
+	printf(">>> Image width   = %i\n", width);
+	printf(">>> Image height  = %i\n", height);
+	printf(">>> Buffer length = %i\n", bufferinfo.length);
 
 	void * buffer_start = mmap(NULL, bufferinfo.length, PROT_READ | PROT_WRITE,MAP_SHARED, fd, bufferinfo.m.offset);
 
 	if(buffer_start == MAP_FAILED){
-		perror(RED "mmap" WHT);
+		perror("mmap");
 		exit(1);
 	}
 
@@ -337,7 +163,7 @@ int main(int argc, char** argv )
 	// Activate streaming
 	int type = bufferinfo.type;
 	if(ioctl(fd, VIDIOC_STREAMON, &type) < 0){
-		perror(RED "VIDIOC_STREAMON" WHT);
+		perror("VIDIOC_STREAMON");
 		exit(1);
 	}
 
@@ -352,87 +178,35 @@ int main(int argc, char** argv )
     	// Will be used or not depending on program arguments
 	Size size(640,512);
 	Mat thermal16_linear_zoom;   // (height,width, CV_8U, 1);    // Final representation
-	Mat thermal_rgb_zoom;   // (height,width, CV_8U, 1);    // Final representation
-
-	int luma_height ;
-	int luma_width ;
-	int color_space ;;
-
-	// Declarations for 8bits YCbCr mode
-        // Will be used in case we are reading YUV format
-	// Boson320, 640 :  4:2:0
-	luma_height = height+height/2;
-	luma_width = width;
-	color_space = CV_8UC1;
- 	Mat thermal_luma(luma_height, luma_width,  color_space, buffer_start);  // OpenCV input buffer
-	Mat thermal_rgb(height, width, CV_8UC3, 1);    // OpenCV output buffer , BGR -> Three color spaces (640 - 640 - 640 : p11 p21 p31 .... / p12 p22 p32 ..../ p13 p23 p33 ...)
 
 	// Reaad frame, do AGC, paint frame
 	for (;;) {
 
 		// Put the buffer in the incoming queue.
 		if(ioctl(fd, VIDIOC_QBUF, &bufferinfo) < 0){
-			perror(RED "VIDIOC_QBUF" WHT);
+			perror("VIDIOC_QBUF");
 			exit(1);
 		}
 
 		// The buffer's waiting in the outgoing queue.
 		if(ioctl(fd, VIDIOC_DQBUF, &bufferinfo) < 0) {
-			perror(RED "VIDIOC_QBUF" WHT);
+			perror("VIDIOC_QBUF");
 			exit(1);
 		}
 
 
 		// -----------------------------
 		// RAW16 DATA
-		if ( video_mode==RAW16 ) {
-			AGC_Basic_Linear(thermal16, thermal16_linear, height, width);
+                AGC_Basic_Linear(thermal16, thermal16_linear, height, width);
 
-			// Display thermal after 16-bits AGC... will display an image
-			if (zoom_enable==0) {
-                		sprintf(label, "%s : RAW16  Linear", thermal_sensor_name);
-                    		imshow(label, thermal16_linear);
-          		} else {
-			        resize(thermal16_linear, thermal16_linear_zoom, size);
-                     		sprintf(label, "%s : RAW16  Linear Zoom", thermal_sensor_name);
-                     		imshow(label, thermal16_linear_zoom);
-                	}
-
-
-	        	if (record_enable==1) {
-        	        	sprintf(filename, "%s_raw16_%lu.tiff", thermal_sensor_name, frame);
-                		imwrite(filename, thermal16 , compression_params );
-                        	sprintf(filename, "%s_agc_%lu.tiff", thermal_sensor_name, frame);
-                        	imwrite(filename, thermal16_linear , compression_params );
-				frame++;
-                	}
-          	}
-
-
-		// ---------------------------------
-		// DATA in YUV
-		else {  // Video is in 8 bits YUV
-            		cvtColor(thermal_luma, thermal_rgb, COLOR_YUV2RGB_I420, 0 );   // 4:2:0 family instead of 4:2:2 ...
-
-        		sprintf(label, "%s : 8bits", thermal_sensor_name);
-		        imshow(label, thermal_rgb);
-
-			if (record_enable==1) {
-                        	sprintf(filename, "%s_yuv_%lu.tiff", thermal_sensor_name, frame);
-                        	imwrite(filename, thermal_rgb , compression_params );
-				frame++;
-                	}
-
-		}
+                // Display thermal after 16-bits AGC... will display an image
+                resize(thermal16_linear, thermal16_linear_zoom, size);
+                sprintf(label, "%s : RAW16  Linear Zoom", thermal_sensor_name);
+                imshow(label, thermal16_linear_zoom);
 
 		// Press 'q' to exit
 		if( waitKey(1) == 'q' ) { // 0x20 (SPACE) ; need a small delay !! we use this to also add an exit option
-			printf(WHT ">>> " RED "'q'" WHT " key pressed. Quitting !\n");
-			break;
-		}
-		// Stop if frame limit reached.
-		if (video_frames>0 && frame+1 > video_frames) {
-			printf(WHT ">>>" GRN "'Done'" WHT " Frame limit reached, Quitting !\n");
+			printf(">>> 'q' key pressed. Quitting !\n");
 			break;
 		}
 	}
@@ -440,7 +214,7 @@ int main(int argc, char** argv )
 
 	// Deactivate streaming
 	if( ioctl(fd, VIDIOC_STREAMOFF, &type) < 0 ){
-		perror(RED "VIDIOC_STREAMOFF" WHT);
+		perror("VIDIOC_STREAMOFF");
 		exit(1);
 	};
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,0 @@
-cmake_minimum_required(VERSION 2.8)
-project( BosonUSB )
-include_directories( ${MY_SOURCE_DIR}/src )
-add_executable( BosonUSB BosonUSB.cpp )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
 cmake_minimum_required(VERSION 2.8)
 project( BosonUSB )
 include_directories( ${MY_SOURCE_DIR}/src )
-find_package( OpenCV REQUIRED )
 add_executable( BosonUSB BosonUSB.cpp )
-target_link_libraries( BosonUSB ${OpenCV_LIBS} )
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+EXEC      = bosond
+SRC_FILES = bosond.cpp
+
+CXX = g++
+CC = $(CXX)
+
+# What flags should be passed to the compiler
+
+DEBUG_LEVEL     = -g
+EXTRA_CCFLAGS   = -Wall
+CXXFLAGS        = $(DEBUG_LEVEL) $(EXTRA_CCFLAGS)
+CCFLAGS         = $(CXXFLAGS)
+O_FILES         = $(SRC_FILES:%.cpp=%.o)
+
+all: $(EXEC)
+
+$(EXEC): $(O_FILES)
+
+.PHONY: clean
+clean:
+	rm -f ${EXEC} ${O_FILES}

--- a/README.md
+++ b/README.md
@@ -1,65 +1,48 @@
-FLIR SYSTEMS, INC <BR>
-2018-Nov <BR>
-MIT License <BR>
+# bosond
 
-# Description:
+This service streams frames from a FLIR Boson camera connected as a
+USB video device to a
+[thermal-recorder](https://github.com/TheCacophonyProject/thermal-recorder)
+compatible Unix domain socket.
 
-This is an example of capturing Boson Video (USB) using V4L2 (Video for Linux 2)
-and OpenCV to display the video. Boson USB has two modes, AGC-8 bits and
-RAW-16bits.
 
-Video in 16 bits is not paintable so a linear transformation needs to happen
-before displaying the image. We call this process AGC, and in this example we
-use the most basic one (LINEAR). Then we use stardard call to paint in GREY.
-Video is 8 bits is directly paintable, linear transformation happens inside the
- camera, not further actions need to happen in SW.
+## Usage
 
-To Display Boson data we are using OpenCV to convert from YUV to RGB.
-
-# How to use it:
 ```
-BosonUSB [r/y/a/b/z/f/t] [0..9] 
-	r    : raw video
-	y    : 8 bits
-	z    : zoom mode to 640x480
-	f<name>    : record TIFFS in Folder <NAME>
-	t<video_frames> : record a certain number of frames being <video_frames> default sets to 0 which sets no limit
-	s[b,B] : b=boson320, B=boson640   
-	[0..9]: video port
+   ./bosond  [-t <bool>] [-p <string>] [-d <int>] [--] [--version] [-h]
 
-./BosonUSB    ->  opens Boson320 /dev/video0  in RAW16 mode
-./BosonUSB r  ->  opens Boson320 /dev/video0  in RAW16 mode
-./BosonUSB y  ->  opens Boson320 /dev/video0  in AGC-8bits mode
-./BosonUSB sB 1   ->  opens Boson640 /dev/video1  in RAW16 mode
-./BosonUSB sB y 2 ->  opens Boson640 /dev/video2  in AGC-8bits mode
-./BosonUSB fcap -> Captures RAW16 frames and stores them as TIFF files in 'cap' folder.
-		   If in RAW16 mode then RAW16 and Linear_AGC are captured per frame
-		   If in AGC-8 mode then YUV TIFF only are captured per frame
-./BosonUSB fcap t100 -> Captures RAW16 frames and stores them as TIFF files in 'cap' folder and only captures 100 frames
+Where:
+
+   -t <bool>,  -- <bool>
+     Print frame timings
+
+   -p <string>,  --socket-path <string>
+     Path to output socket
+
+   -d <int>,  --device <int>
+     Video device number to use
+
+   --,  --ignore_rest
+     Ignores the rest of the labeled arguments following this flag.
+
+   --version
+     Displays version information and exits.
+
+   -h,  --help
+     Displays usage information and exits.
+
+
+   Read FLIR Boson frames
 ```
 
-# To compile
+## Building
 
-This SW uses some libraries as v4l2 and OpenCv, they need to be installed first in the PC.
-They are not part of this package
 ```
-cmake .
-make
-
-(if CMakeCache.txt exists remove it first time)
+$ sudo apt install libtclap-dev
+$ make
 ```
 
-# How to clean the full project
-```
-make clean
-rm -rf CMakeFiles
-rm CMakeCache.txt
-rm cmake_install.cmake
-rm Makefile
-```
+## References
 
-# References and Credits (other than FLIR)
-
-- http://jwhsmith.net/2014/12/capturing-a-webcam-stream-using-v4l2
-- https://opencv.org
+- https://github.com/FLIR/BosonUSB
 - https://en.wikipedia.org/wiki/Video4Linux

--- a/bosond.cpp
+++ b/bosond.cpp
@@ -6,6 +6,10 @@
 #include <unistd.h>              // close
 #include <sys/ioctl.h>           // ioctl
 #include <sys/mman.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
 #include <linux/videodev2.h>
 
 
@@ -116,6 +120,17 @@ int main(int argc, char** argv)
 
     // Fill this buffer with ceros. Initialization. Optional but nice to do
     memset(buffer_start, 0, bufferinfo.length);
+
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+
+    struct sockaddr_un addr = { .sun_family = AF_UNIX };
+    strncpy(addr.sun_path, "/var/run/lepton-frames", sizeof(addr.sun_path)-1);
+
+    if (connect(sock, (sockaddr*) (&addr), sizeof(addr)) < 0) {
+        perror("CONNECT");
+        exit(1);
+    }
+
 
     // Activate streaming
     int type = bufferinfo.type;

--- a/bosond.cpp
+++ b/bosond.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
     int width;
     int height;
 
-    sprintf(video, "/dev/video1");
+    sprintf(video, "/dev/video0");
     width=640;
     height=512;
 


### PR DESCRIPTION
Started at https://github.com/FLIR/BosonUSB and converted to bosond, a service to read FLIR Boson frames and send them to thermal-recorder or similar.

- simplified code (removed use of OpenCV etc)
- renamed to `bosond`
- simplified building setup
- connect to Unix socket and send headers that thermal-recorder expects
- use more C++ idioms
- updated README
